### PR TITLE
Fix: Clean up app_bar_main.xml

### DIFF
--- a/app/src/main/res/layout/app_bar_main.xml
+++ b/app/src/main/res/layout/app_bar_main.xml
@@ -8,18 +8,12 @@
 
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:theme="@style/ThemeOverlay.Material3.Toolbar">
+        android:layout_height="wrap_content">
 
-        <!--
-        CRUCIAL FIX: The MaterialToolbar must be PROPERLY NESTED
-        inside the AppBarLayout, between its opening and closing tags.
-        -->
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
-            app:popupTheme="@style/ThemeOverlay.Material3.PopupMenu" />
+            android:layout_height="?attr/actionBarSize" />
 
     </com.google.android.material.appbar.AppBarLayout>
 


### PR DESCRIPTION
I removed a misleading comment regarding MaterialToolbar nesting. I also removed explicit theme and popupTheme attributes from AppBarLayout and MaterialToolbar respectively, allowing them to inherit themes from your application's main theme.

This addresses potential confusion and aligns the layout with standard Material 3 practices. Build verification was skipped due to an SDK configuration issue in the build environment.